### PR TITLE
Fix waiting time calculation for unloading station queue

### DIFF
--- a/simulation/implementation/UnloadingStation.cpp
+++ b/simulation/implementation/UnloadingStation.cpp
@@ -35,7 +35,9 @@ Events UnloadingStation::enqueue(ITruck* truck) {
     // Truck needs to wait 
     auto events = truck->startWaiting();
     auto& unloadEvent = events.front();
-    unloadEvent.duration = WAIT_TIME * m_queue.size();
+    // Account for the truck currently unloading by adding 1
+    // to the number of vehicles already waiting in the queue.
+    unloadEvent.duration = WAIT_TIME * (m_queue.size() + 1);
     m_queue.push(truck);
 
     if (m_callback) 


### PR DESCRIPTION
## Summary
- fix waiting event duration in UnloadingStation so queued trucks wait the correct time

## Testing
- `clang++ -std=c++20 ... -lgtest -lpthread -o build/main.app` *(fails: 'gtest/gtest.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8c7149488321950c2bbbca7cb3a7