### PR TITLE
Fix spelling mistakes and parameter names

### DIFF
--- a/simulation/common/State.h
+++ b/simulation/common/State.h
@@ -5,7 +5,7 @@
 namespace Helium3 {
 
 /**
- *  State of the IMachien Idle, Mining etc
+ *  State of the IMachine: Idle, Mining, etc.
  * let's start simple, then State can be replaced by class and grow
  */
 using State = int;

--- a/simulation/implementation/Log.cpp
+++ b/simulation/implementation/Log.cpp
@@ -9,8 +9,8 @@ namespace Helium3 {
 namespace {
 
 const ILog::MachineSummary UNDEFINED{
-    { {"Undefined", {}} },   // complette
-    { {"Undefined", {}} }    // unfinshed
+    { {"Undefined", {}} },   // complete
+    { {"Undefined", {}} }    // unfinished
 };
 
 } //end of anonimous namespace 
@@ -34,16 +34,16 @@ void Log::add(const Event& e, TaskState taskState)
     //m_events.push_back(e);
 
     auto& machineStat = m_stats[e.machineId];
-    auto& collection = taskState == TaskState::Complette ? machineStat.complette : machineStat.unfinshed;
+    auto& collection = taskState == TaskState::Complete ? machineStat.complete : machineStat.unfinished;
     auto& record = collection[e.name];
 
     record.occurrences++;
     record.totalDuration += e.duration;
 }
 
-const ILog::MachineSummary& Log::summary(const std::string& machienId) const 
+const ILog::MachineSummary& Log::summary(const std::string& machineId) const 
 {
-    if(auto it = m_stats.find(machienId); it != m_stats.end())
+    if(auto it = m_stats.find(machineId); it != m_stats.end())
         return it->second;
 
     return UNDEFINED;

--- a/simulation/implementation/Log.h
+++ b/simulation/implementation/Log.h
@@ -19,7 +19,7 @@ public:
 
     // --- From ITruck ---
     void add(const Event& e, TaskState taskState) override;
-    const MachineSummary& summary(const std::string& machienId) const override;
+    const MachineSummary& summary(const std::string& machineId) const override;
 
 private: 
     VerboseLevel m_level;

--- a/simulation/implementation/MiningTruck.cpp
+++ b/simulation/implementation/MiningTruck.cpp
@@ -31,7 +31,7 @@ const std::unordered_map<MiningTruck::StateID, std::string> STATE_MESSAGES = {
     {MiningTruck::MovingToStation,  "Moving for unloading"},
     {MiningTruck::ArrivedToStation, "Arrived for unloading"},
     {MiningTruck::WaitingToUnload,  "Waiting for unloading"},
-    {MiningTruck::Unloading,        "Unloading in progresss"},
+    {MiningTruck::Unloading,        "Unloading in progress"},
     {MiningTruck::MovingToMining,   "Returning for mining"}
 };
 

--- a/simulation/implementation/UnloadingStation.h
+++ b/simulation/implementation/UnloadingStation.h
@@ -31,7 +31,7 @@ public:
     enum StateID {
         Idle = -1,     ///< Initial or reset state
         Unloading,     ///< Actively unloading a truck
-        Waiting        ///< Not uloading and no trucks in queue, waiting for Truck arrival
+        Waiting        ///< Not unloading and no trucks in queue, waiting for Truck arrival
     };
 
 

--- a/simulation/interfaces/ILog.h
+++ b/simulation/interfaces/ILog.h
@@ -11,7 +11,7 @@ public:
     virtual ~ILog() = default;
 
     enum class TaskState {
-        Complette,
+        Complete,
         Unfinished
     };
 
@@ -20,12 +20,12 @@ public:
         Duration totalDuration{};
     };
     struct MachineSummary {
-        std::map<std::string, StateSummary> complette;
-        std::map<std::string, StateSummary> unfinshed;
+        std::map<std::string, StateSummary> complete;
+        std::map<std::string, StateSummary> unfinished;
     };
 
-    virtual void add(const Event& e, TaskState taskState = TaskState::Complette) = 0;
-    virtual const MachineSummary& summary(const std::string& machienId) const = 0;
+    virtual void add(const Event& e, TaskState taskState = TaskState::Complete) = 0;
+    virtual const MachineSummary& summary(const std::string& machineId) const = 0;
 };
 
 }   //end of namespace Helium3

--- a/simulation/testing/PredictedTest.cpp
+++ b/simulation/testing/PredictedTest.cpp
@@ -26,7 +26,7 @@ INSTANTIATE_TEST_SUITE_P(
             {{
                 {"Truck_0", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Mining",    {5, std::chrono::hours(5)}},
                         {"Moving",    {9, std::chrono::minutes(270)}},
                         {"Arrived",   {5, std::chrono::minutes(0)}},
@@ -39,7 +39,7 @@ INSTANTIATE_TEST_SUITE_P(
                 }},
                 {"Station_0", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Unloading", {5, std::chrono::minutes(25)}}
                     }},
                     {
@@ -53,7 +53,7 @@ INSTANTIATE_TEST_SUITE_P(
             {{
                 {"Truck_0", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Mining",    {5, std::chrono::hours(5)}},
                         {"Moving",    {9, std::chrono::minutes(270)}},
                         {"Arrived",   {5, std::chrono::minutes(0)}},
@@ -66,7 +66,7 @@ INSTANTIATE_TEST_SUITE_P(
                 }},
                 {"Truck_1", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Mining",    {5, std::chrono::hours(5)}},
                         {"Moving",    {9, std::chrono::minutes(270)}},
                         {"Arrived",   {5, std::chrono::minutes(0)}},
@@ -79,7 +79,7 @@ INSTANTIATE_TEST_SUITE_P(
                 }},
                 {"Station_0", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Unloading", {5, std::chrono::minutes(25)}}
                     }},
                     {
@@ -88,7 +88,7 @@ INSTANTIATE_TEST_SUITE_P(
                 }},
                 {"Station_1", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Unloading", {5, std::chrono::minutes(25)}}
                     }},
                     {
@@ -103,7 +103,7 @@ INSTANTIATE_TEST_SUITE_P(
                 
                 {"Truck_0", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Mining",    {5, std::chrono::hours(5)}},
                         {"Moving",    {9, std::chrono::minutes(270)}},
                         {"Arrived",   {5, std::chrono::minutes(0)}},
@@ -117,7 +117,7 @@ INSTANTIATE_TEST_SUITE_P(
                 }},
                 {"Truck_1", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Mining",    {5, std::chrono::hours(5)}},
                         {"Moving",    {9, std::chrono::minutes(270)}},
                         {"Arrived",   {5, std::chrono::minutes(0)}},
@@ -130,7 +130,7 @@ INSTANTIATE_TEST_SUITE_P(
                 }},
                 {"Station_0", ILog::MachineSummary{
                     {{
-                        // complette
+                        // complete
                         {"Unloading", {9, std::chrono::minutes(45)}}
                     }},
                     {{
@@ -145,7 +145,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 
 /*
-Check against predicted resuslts for fixed time mining
+Check against predicted results for fixed time mining
 */
 TEST_P(PredictedTest, BasicSimulationRuns) 
 {
@@ -156,9 +156,9 @@ TEST_P(PredictedTest, BasicSimulationRuns)
     {
         const auto& actualSummary = m_simulation->log().summary(machineId);
 
-        for (const auto& [state, expectedState] : expectedSummary.complette) 
+        for (const auto& [state, expectedState] : expectedSummary.complete) 
         {
-            const auto& actualState = actualSummary.complette.at(state);
+            const auto& actualState = actualSummary.complete.at(state);
             
             std::cout << "[Check] " << machineId << " - " << state
                 << ": expected " << expectedState.occurrences << "x/" << toString(expectedState.totalDuration) << ", "
@@ -173,23 +173,23 @@ TEST_P(PredictedTest, BasicSimulationRuns)
 
 inline void PrintTo(const Helium3::Testing::PredictedParams& params, std::ostream* os) {
     *os << "PredictedParams {\n"
-        << "  trucks   = " << params.simulatonParams.truckCount << ",\n"
-        << "  stations = " << params.simulatonParams.stationCount << ",\n"
+        << "  trucks   = " << params.simulationParams.truckCount << ",\n"
+        << "  stations = " << params.simulationParams.stationCount << ",\n"
         << "  duration = " 
-        << std::chrono::duration_cast<std::chrono::hours>(params.simulatonParams.simulationLength).count() << "h,\n"
+        << std::chrono::duration_cast<std::chrono::hours>(params.simulationParams.simulationLength).count() << "h,\n"
         << "  expected = {\n";
 
     for (const auto& [machineId, summary] : params.expectedSummary) {
         *os << "    " << machineId << " => {\n";
-        *os << "      complette = {\n";
-        for (const auto& [state, stats] : summary.complette) {
+        *os << "      complete = {\n";
+        for (const auto& [state, stats] : summary.complete) {
             *os << "        " << state
                 << ": (" << stats.occurrences << "x, "
                 << std::chrono::duration_cast<std::chrono::minutes>(stats.totalDuration).count() << "m)\n";
         }
         *os << "      },\n";
-        *os << "      unfinshed = {\n";
-        for (const auto& [state, stats] : summary.unfinshed) {
+        *os << "      unfinished = {\n";
+        for (const auto& [state, stats] : summary.unfinished) {
             *os << "        " << state
                 << ": (" << stats.occurrences << "x, "
                 << std::chrono::duration_cast<std::chrono::minutes>(stats.totalDuration).count() << "m)\n";

--- a/simulation/testing/PredictedTest.h
+++ b/simulation/testing/PredictedTest.h
@@ -5,10 +5,10 @@
 namespace Helium3::Testing {
 
 /*
-This test is used with non-random mining / predicatable mining duratons 
+This test is used with non-random mining / predictable mining durations 
 */
 struct PredictedParams {
-    SimulationParams simulatonParams;
+    SimulationParams simulationParams;
     std::unordered_map<std::string, ILog::MachineSummary> expectedSummary;
 };
 
@@ -16,7 +16,7 @@ struct PredictedParams {
 class PredictedTest : public SimulationTest, public ::testing::TestWithParam<PredictedParams> {
 protected:
     void SetUp() override {
-        init(GetParam().simulatonParams);
+        init(GetParam().simulationParams);
     }
 };
 


### PR DESCRIPTION
## Summary
- correct a handful of misspellings across the codebase
- rename parameters like `machienId` → `machineId`
- update logging API and tests to use `complete`/`unfinished`
- fix progress and unloading comments/messages

## Testing
- `g++ -std=c++17 -Isimulation -Isimulation/interfaces -Isimulation/implementation -Isimulation/common -Isimulation/testing main.cpp simulation/testing/PredictedTest.cpp simulation/implementation/Simulation.cpp simulation/implementation/TrucksManager.cpp simulation/implementation/MiningTruck.cpp simulation/implementation/UnloadingStation.cpp simulation/implementation/StationManager.cpp simulation/implementation/Log.cpp -o main -lgtest -pthread` *(fails: gtest/gtest.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfb7049248321b0b882fffe9a912b